### PR TITLE
unreferencing img onload and img to release img for garbage collection

### DIFF
--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1,5 +1,5 @@
 // Imports
-const {remote, ipcRenderer} = require("electron");
+const {remote, ipcRenderer, webFrame} = require("electron");
 const $ = require("jquery");
 window.jQuery = $;
 const Swal = require("sweetalert2");
@@ -328,6 +328,8 @@ function loadImage(isNext, fadeTime, goToLatest = false) {
           loadImage(true, fadeTime);
         }, img.duration * 1000);
       }
+      img.onloadeddata = null;
+      img = null;
     };
   } else {
     img.onload = function() {
@@ -359,6 +361,8 @@ function loadImage(isNext, fadeTime, goToLatest = false) {
           loadImage(true, config.fadeTime);
         }, config.interval);
       }
+      img.onload = null;
+      img = null;
     };
   }
 
@@ -371,6 +375,7 @@ function loadImage(isNext, fadeTime, goToLatest = false) {
   }
   setTimeout(function() {
     container.removeChild(currentImage);
+    webFrame.clearCache()
   }, fadeTime)
 
   container.appendChild(div);


### PR DESCRIPTION
fixes the memory leak that caused #26. 