### PR TITLE
Let the bot only answer on messages starting with "hi"

### DIFF
--- a/js/bot.js
+++ b/js/bot.js
@@ -136,7 +136,7 @@ var Bot = class {
     });
 
     //Some small conversation
-    this.bot.hears(/hi/i, (ctx) => {
+    this.bot.hears(/^hi/i, (ctx) => {
       ctx.reply(
         `Hey there ${ctx.chat.first_name} \nYour ChatID is ${ctx.chat.id}`
       );


### PR DESCRIPTION
Helpful if the bot is part of a group. Otherwise, the bot would spam the group if the messages contain "hi" at any place