### PR TITLE
Delete outdated files, when popping them from images list

### DIFF
--- a/js/imageWatchdog.js
+++ b/js/imageWatchdog.js
@@ -39,8 +39,16 @@ var ImageWatchdog = class {
       'chatName': chatName,
       'messageId': messageId
     });
-    if (this.images.length >= this.imageCount) {
-      this.images.pop();
+    if (this.images.length > this.imageCount) {
+	// delete image / video file before popping. Prevent an overfull harddrive
+	try {
+	  var oldSrc = this.images[this.imageCount].src;
+	  fs.unlinkSync(oldSrc);
+	  this.logger.info("Deleted file " + oldSrc);
+	} catch(err) {
+	  this.logger.error('An error occured while deleting the file ' + oldSrc + ':\n' + err);
+	}
+	this.images.pop();
     }
     //notify frontend, that new image arrived
 		var type;


### PR DESCRIPTION
Prevent overfull harddrive / SD card. Old images are no more needed (and even no more accessible to the frontend) after popping them from images-list.

Besides, fixed off-by-one error when comparing length with image count