### PR TITLE
Bot reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The following properties can be configured:
 | `toggleMonitor`      | When set to true, TeleFrame will switch the monitor off and on at the defined hours.                                                                                 |
 | `turnOnHour`         | Defines when the monitor should be turned on.                                                                                                                        |
 | `turnOffHour`        | Defines when the monitor should be turned off.                                                                                                                       |
+| `botReply`           | Defines if the bot should answer on images or videos with a short reply (:+1: :camera_flash: for images, :+1: :movie_camera: for movies). Also throws a warning on receiving unknown file extensions. |
 | `confirmDeleteImage` | Defines if to show a confirm message before delete an image `true` or `false`                                                                                        |
 | `confirmShutdown`    | Defines if to show a confirm message before shutdown the system `true` or `false`                                                                                    |
 | `confirmReboot`      | Defines if to show a confirm message before rebooting the system `true` or `false`                                                                                   |

--- a/config/i18n/de.js
+++ b/config/i18n/de.js
@@ -30,7 +30,9 @@ var i18n = {
   // Text der ausgegeben wird, wenn die Sprachnachricht gesendet wurde
   recordingDone: "Sprachnachricht erfolgreich gesendet!",
   // Text der ausgegeben wird, wenn ein Fehler bei der Aufzeichnug der Sprachnachricht auftrat
-  recordingError: "Aufzeichnung fehlgeschlagen!"
+  recordingError: "Aufzeichnung fehlgeschlagen!",
+  // Text der ausgegeben wird, wenn das empfangene Dokument ein nicht unterstütztes Dateiformat hat
+  documentFormatError: "Dieses Dokument hat ein unbekanntes Dateiformat."
 };
 
 /*************** DO NOT EDIT THE LINE BELOW ***************/

--- a/config/i18n/en.js
+++ b/config/i18n/en.js
@@ -30,7 +30,9 @@ var i18n = {
   // The message of the recording dialog displayed on the frame when recording has finished
   recordingDone: "Voice message sent sucessfully!",
   // The error message of the recording dialog displayed when recording has failed
-  recordingError: "Voice message has failed!"
+  recordingError: "Voice message has failed!",
+  // The error message if the received document has unknown format
+  documentFormatError: "This document has an unknown format."
 };
 
 /*************** DO NOT EDIT THE LINE BELOW ***************/

--- a/js/bot.js
+++ b/js/bot.js
@@ -108,14 +108,26 @@ var Bot = class {
       } else if (ctx.updateSubTypes.indexOf('document') > -1) {
         fileId = ctx.message.document.file_id;
       }
+      
 
       this.telegram.getFileLink(fileId).then((link) => {
         // check for supported file types
         if (link.match(/\.(mp4|jpg|gif|png)$/) === null) {
+          if (config.botReply) {
+            ctx.reply(config.phrases.documentFormatError)  
+          }
           return;
         }
 
         let fileExtension = '.' + link.split('.').pop();
+        // let bot reply, if wanted
+        if (config.botReply) {
+            if (fileExtension.match(/\.(mp4|gif)$/)){
+              ctx.reply("\u{1F44D}\u{1F3A5}");  
+            } else if (fileExtension.match(/\.(jpg|png)$/)){
+              ctx.reply("\u{1F44D}\u{1F4F8}");
+            }
+        }
         if (fileExtension !== '.mp4' || this.showVideo) {
           download
             .image({

--- a/js/defaultConfig.js
+++ b/js/defaultConfig.js
@@ -57,7 +57,7 @@ var defaultConfig = {
   turnOffHour: 22,
   
   // Defines if the bot should answer on images or videos with a short reply
-  botReply: false,
+  botReply: true,
 
   touchBar: {
     height: "75px",

--- a/js/defaultConfig.js
+++ b/js/defaultConfig.js
@@ -55,6 +55,9 @@ var defaultConfig = {
 
   // Defines when the monitor shuld be turned off.
   turnOffHour: 22,
+  
+  // Defines if the bot should answer on images or videos with a short reply
+  botReply: false,
 
   touchBar: {
     height: "75px",


### PR DESCRIPTION
Hi,
as mentioned in #91, I implemented a reply of the bot on incoming media. There is a new config file parameter `botReply` for it. ( :+1: :movie_camera: for videos, :+1: :camera_flash: for images) 

Since the bot.js changed pretty much in order to handle documents as gifs, I created this PR to this feature branch #85 . It is a very minimalistic implementation, which can simply be merged into that branch.

@gegu @LoiX07, I'd need your help for the vienna slang and french strings :)  