### PR TITLE
English phrases as fallback

### DIFF
--- a/js/initLanguage.js
+++ b/js/initLanguage.js
@@ -1,9 +1,11 @@
+
 const fs = require('fs');
 
 module.exports = (config) => {
   // initialize localized texts
   const configPath = __dirname + '/../config/';
   const langPath =  configPath + 'i18n/';
+  let defaultLangFile = langPath + 'en.js';
   let langFile = configPath + 'texts.js';
   let mergeCurrentConfigTexts = false;
   // Does users language file 'config/tests.js' exist?
@@ -22,7 +24,7 @@ module.exports = (config) => {
         // whithout country - 'en'
         langFile =  langPath + `${envLang.substr(0, envLang.indexOf('_'))}.js`;
         if(!fs.existsSync(langFile)) {
-          langFile = langPath + 'en.js';
+          langFile = defaultLangFile;
         }
       }
       // keep the texts defined in the current config
@@ -31,8 +33,20 @@ module.exports = (config) => {
   }
   // load the language
   config.phrases = require(langFile);
-
-  // remove unused text configuration options
+  
+  // include fallback phrases from default language (english)
+  var fallbackPhrases = require(defaultLangFile);
+  var fallbackKeys = Object.keys(fallbackPhrases);
+  for (const keyNo in fallbackKeys) {
+    // following should always be true. 
+    // Won't need to check for `mergeCurrentConfigTexts`, just in case the user forgot some strings
+    if (!config.phrases.hasOwnProperty(fallbackKeys[keyNo])) {
+      config.phrases[fallbackKeys[keyNo]] = fallbackPhrases[fallbackKeys[keyNo]];
+      console.log("initLanguage: Including undefined phrase: " + fallbackKeys[keyNo]);
+    }
+  }
+  
+  // remove unused text configuration options defined in config.js
   for (const phraseKey in Object.keys(config.phrases)) {
     if (mergeCurrentConfigTexts && typeof config[phraseKey] === 'string') {
       config.phrases[phraseKey] = config[phraseKey];


### PR DESCRIPTION
If some phrases are undefined in a specific language file, they are fetched from the english definition. This one should thus be kept up to date.

Referring my request in #95 