### PR TITLE
Feature/dev fixes

### DIFF
--- a/js/initLanguage.js
+++ b/js/initLanguage.js
@@ -15,9 +15,9 @@ module.exports = (config) => {
       // fallback - load the language file for the current environment setting
       // in addition, always merge the current configuration last in order
       // to keep the texts of the user settings.
-      let envLang = process.env.LANG;
+      let envLang = process.env.LANG || ''; // fallback to empty string to support development under windows
       // including country - 'en_US'
-      langFile =  langPath + `${envLang.substr(0, envLang.indexOf('.'))}.js`;
+      langFile = langPath + `${envLang.substr(0, envLang.indexOf('.'))}.js`;
       if(!fs.existsSync(langFile)) {
         // whithout country - 'en'
         langFile =  langPath + `${envLang.substr(0, envLang.indexOf('_'))}.js`;
@@ -37,7 +37,7 @@ module.exports = (config) => {
     if (mergeCurrentConfigTexts && typeof config[phraseKey] === 'string') {
       config.phrases[phraseKey] = config[phraseKey];
     }
-    if (typeof config.voiceReply[phraseKey] === 'string') {
+    if (config.voiceReply !== null && typeof config.voiceReply[phraseKey] === 'string') {
       if (mergeCurrentConfigTexts) {
         config.phrases[phraseKey] = config.voiceReply[phraseKey];
       }

--- a/main.js
+++ b/main.js
@@ -39,7 +39,6 @@ function createWindow() {
     webPreferences: {
       nodeIntegration: true
     },
-    frame: false
   });
 
   win.setFullScreen(config.fullscreen);


### PR DESCRIPTION
The following has been fixed:

- `frame: false` has been removed from the `BrowserWindow`-options, because the menu is no longer automatically displayed at startup since the last update of electron.
The `Alt` key is currently not working, but we can use `F11`.
- Starting TeleFrame under windows using the default settings did not work, because `env.lang` is undefined
- Starting errors if `config.voiceReply == null`
