### PR TITLE
add cropZoomImgs option for fullscreen images

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The following properties can be configured:
 | `autoDeleteImages`   | Defines if old images should be deleted, when they are no longer used in the slideshow (see 'imageCount'). Starred images will not be deleted.                       |
 | `showSender`         | When set to true, TeleFrame will show the name of the sender when the image is shown.                                                                                |
 | `showCaption`        | When set to true, TeleFrame will show the caption of the image when the image is shown.                                                                              |
-| `fullscreen`         | When set to true, TeleFrame will run in fullscreen mode.                                                                                                             |
+| `cropZoomImages`     | When set to true, TeleFrame will crop and zoom images so there is no black border.                                                                                   |
 | `toggleMonitor`      | When set to true, TeleFrame will switch the monitor off and on at the defined hours.                                                                                 |
 | `turnOnHour`         | Defines when the monitor should be turned on.                                                                                                                        |
 | `turnOffHour`        | Defines when the monitor should be turned off.                                                                                                                       |

--- a/js/defaultConfig.js
+++ b/js/defaultConfig.js
@@ -59,6 +59,9 @@ var defaultConfig = {
   // When set to true, TeleFrame will show the caption of the image when the image is shown.
   showCaption: true,
 
+  // When set to true, TeleFrame will crop and zoom images so there is no black border.
+  cropZoomImages: false,
+
   // Defines the percentage of the duration of <interval> to show sender and caption.
   // minimum value: 10  = fade out after 10% of <interval>
   // maximum value: 100 = full time. sender and caption does not fade out

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -681,11 +681,26 @@ function loadImage(isNext, fadeTime, goToLatest = false) {
     //fade in new image while fading out the old image as soon as
     //the new image is loaded
     let css;
-    if (assetAspectRatio > screenAspectRatio) {
-      css = { width: "100%" };
-    } else {
-      css = { height: "100%" };
+
+    switch (config.cropZoomImages) {
+        case true:
+            // zoom to the max, no borders
+            if (assetAspectRatio > screenAspectRatio) {
+                css = { height: "100%" };
+            } else {
+                css = { width: "100%" };
+            }
+            break;
+        default:
+        case false:
+            // show complete image, has borders if ratios don't match
+            if (assetAspectRatio > screenAspectRatio) {
+                css = { width: "100%" };
+            } else {
+                css = { height: "100%" };
+            }
     }
+
     $([$asset, $asset.closest('.imgcontainer')]).each( function(){
         $(this).css(css);
     });


### PR DESCRIPTION
Adding an option to crop and zoom pictures so that no borders are shown if image ratio does not match the screen ratio.