### PR TITLE
Feature/inline config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Also note that:
 
 ## Configuration
 
+### Basic Configuration
+Basic Configuration is very Easy. Just follow these Steps:
+1. Send /start to your Bot
+2. Send /settings to yout Bot an do the Basic Configuration
+
+### Advanced Configuration
+
 1. Copy `TeleFrame/config/config.example.json` to `TeleFrame/config/config.json`. \
    **Note:** If you used the installer script. This step is already done for you.
 

--- a/config/i18n/bot/de.js
+++ b/config/i18n/bot/de.js
@@ -5,6 +5,9 @@ var i18n = {
   whitelistInfo: 'Hallo, dieser Bot benötigt eine Freischaltung. Bitte definiere deine Chat-Id in der Konfigurationsdatei',
   whitelistAdminInfo: 'Hallo, die Administrierung dieses Bots benötigt eine Freischaltung. Bitte definiere deine Chat-Id in der Konfigurationsdatei',
   hiReply: (name, chatId) => `Hallo ${name} \nDeine ChatID ist ${chatId}`,
+  hiAdminPrivateReply: (first_name, last_name, chatId) => `Hey Admin! \n${first_name} ${last_name} möchte seinen Chat mit der ID ${chatId} auf die Whitelist gesetzt bekommen.`,
+  hiAdminGroupReply: (first_name, last_name, groupName, chatId) => `Hey Admin! \n${first_name} ${last_name} möchte die Gruppe '${groupName}' mit der ID ${chatId} auf die Whitelist gesetzt bekommen.`,
+
   // Text der ausgegeben wird, wenn das empfangene Dokument ein nicht unterstütztes Dateiformat hat
   documentFormatError: 'Dieses Dokument hat ein unbekanntes Dateiformat.',
 };

--- a/config/i18n/bot/en.js
+++ b/config/i18n/bot/en.js
@@ -17,6 +17,12 @@ var i18n = {
   // reply to 'hi' requires additional parameters - use a function
   hiReply: (name, chatId) => `Hey there ${name} \nYour ChatID is ${chatId}`,
 
+  // reply for admin on welcome message from user
+  hiAdminPrivateReply: (first_name, last_name, chatId) => `Hey Admin! \n${first_name} ${last_name} wants to add his Chat with the ID ${chatId}.`,
+
+  // reply for admin on welcome message from user in a group
+  hiAdminGroupReply: (first_name, last_name, groupName, chatId) => `Hey Admin! \n${first_name} ${last_name} wants to add the Group '${groupName}' with ID ${chatId}.`,
+
   // The error message if the received document has unknown format
   documentFormatError: 'This document has an unknown format.',
 

--- a/js/bot.js
+++ b/js/bot.js
@@ -1,12 +1,14 @@
 const Telegraf = require("telegraf");
 const Telegram = require("telegraf/telegram");
 const Extra = require('telegraf/extra')
+const {MenuMiddleware} = require('telegraf-inline-menu')
 const download = require("image-downloader");
 const moment = require("moment");
 const exec = require("child_process").exec;
 const fs = require(`fs`);
 const botReply = require('./botReply');
 const botSendMessage = require('./botSendMessage');
+const botConfigMenu = require('./botConfigMenu');
 
 var Bot = class {
   constructor(
@@ -185,6 +187,11 @@ var Bot = class {
       });
 
     }
+
+    //Menu
+    const menuMiddleware = new MenuMiddleware('/', botConfigMenu)
+    this.bot.command('settings', isAdminWhitelisted, async ctx => menuMiddleware.replyToContext(ctx))
+    this.bot.use(menuMiddleware.middleware())
 
     this.logger.info("Bot created!");
   }

--- a/js/bot.js
+++ b/js/bot.js
@@ -6,6 +6,7 @@ const moment = require("moment");
 const exec = require("child_process").exec;
 const fs = require(`fs`);
 const botReply = require('./botReply');
+const botSendMessage = require('./botSendMessage');
 
 var Bot = class {
   constructor(
@@ -29,7 +30,11 @@ var Bot = class {
     });
 
     //Welcome message on bot start
-    this.bot.start((ctx) => botReply(ctx, 'welcome'));
+    this.bot.start((ctx) => this.welcomeUser(ctx));
+
+    //Some small conversation
+    this.bot.hears(/^hi/i, (ctx) => this.welcomeUser(ctx));
+
 
     //Help message
     this.bot.help((ctx) => botReply(ctx, 'help'));
@@ -151,13 +156,6 @@ var Bot = class {
       this.logger.error(err.stack);
     });
 
-    //Some small conversation
-    this.bot.hears(/^hi/i, (ctx) => {
-      botReply(ctx, 'hiReply', ctx.chat.first_name, ctx.chat.id);
-      this.logger.info(ctx.chat);
-    });
-
-
     //Add Admin Actions from config to Bot-Command
     if(this.config.adminAction.allowAdminAction ){
       var actions = this.config.adminAction.actions;
@@ -210,6 +208,26 @@ var Bot = class {
   sendMessage(message) {
     // function to send messages, used for whitlist handling
     return this.bot.telegram.sendMessage(config.whitelistChats[0], message);
+  }
+
+  sendMessageToAdmin(ctx, constant, ...args) {
+    // function to send messages, used for informing Admin
+    config.whitelistAdmins.forEach(element => {
+      this.logger.info(element);
+      botSendMessage(this.bot.telegram, ctx, constant, element, ...args)
+    });
+  }
+
+  welcomeUser(ctx){
+    this.logger.info("User send start command to Bot!");
+
+    if(ctx.chat.type=='private'){
+      botReply(ctx, 'hiReply', ctx.chat.first_name, ctx.chat.id);
+      this.sendMessageToAdmin(ctx, "hiAdminPrivateReply", ctx.chat.first_name, ctx.chat.last_name, ctx.chat.id);
+    }else if(ctx.chat.type=='group'){
+      botReply(ctx, 'hiReply', ctx.chat.title, ctx.chat.id);
+      this.sendMessageToAdmin(ctx, "hiAdminGroupReply", ctx.from.first_name, ctx.from.last_name, ctx.chat.title, ctx.chat.id);
+    }
   }
 
   sendAudio(filename, chatId, messageId) {

--- a/js/botConfigMenu.js
+++ b/js/botConfigMenu.js
@@ -1,0 +1,128 @@
+const langDefault = 'en';
+const langPath = __dirname + '/../config/i18n/bot/';
+const botPhrases = {};
+
+const {MenuTemplate, MenuMiddleware, deleteMenuFromContext} = require('telegraf-inline-menu')
+
+botPhrases[langDefault] = require(langPath + langDefault);
+
+
+const menu = new MenuTemplate(() => 'Configuration-Menu');
+
+menu.toggle('whitelistChats', 'whitelistChats', {
+  set: (_, newState) => {
+    if (newState) {
+      config.whitelistChats = config.whitelistAdmins;
+    } else {
+      config.whitelistChats = [];
+    }
+    config.writeConfig();
+    // Update the menu afterwards
+    return true
+  },
+  isSet: () => config.whitelistChats.length > 0,
+  joinLastRow: false
+})
+
+
+menu.toggle('botReply', 'botReply', {
+  set: (_, newState) => {
+    config.botReply = newState;
+    config.writeConfig();
+    // Update the menu afterwards
+    return true
+  },
+  isSet: () => config.botReply,
+  joinLastRow: false
+})
+
+menu.toggle('showVideos', 'showVideos', {
+  set: (_, newState) => {
+    config.showVideos = newState;
+    config.writeConfig();
+    // Update the menu afterwards
+    return true
+  },
+  isSet: () => config.showVideos,
+  joinLastRow: true
+})
+
+menu.toggle('playVideoAudio', 'playVideoAudio', {
+  set: (_, newState) => {
+    config.playVideoAudio = newState;
+    config.writeConfig();
+    // Update the menu afterwards
+    return true
+  },
+  isSet: () => config.playVideoAudio,
+  joinLastRow: false
+})
+
+menu.toggle('randomOrder', 'randomOrder', {
+  set: (_, newState) => {
+    config.randomOrder = newState;
+    config.writeConfig();
+    // Update the menu afterwards
+    return true
+  },
+  isSet: () => config.randomOrder,
+  joinLastRow: true
+})
+
+menu.toggle('autoDeleteImages', 'autoDeleteImages', {
+  set: (_, newState) => {
+    config.autoDeleteImages = newState;
+    config.writeConfig();
+    // Update the menu afterwards
+    return true
+  },
+  isSet: () => config.autoDeleteImages,
+  joinLastRow: false
+})
+
+menu.toggle('showSender', 'showSender', {
+  set: (_, newState) => {
+    config.showSender = newState;
+    config.writeConfig();
+    // Update the menu afterwards
+    return true
+  },
+  isSet: () => config.showSender,
+  joinLastRow: true
+})
+
+menu.toggle('showCaption', 'showCaption', {
+  set: (_, newState) => {
+    config.showCaption = newState;
+    config.writeConfig();
+    // Update the menu afterwards
+    return true
+  },
+  isSet: () => config.showCaption,
+  joinLastRow: false
+})
+
+menu.toggle('useFullscreenForCaptionAndSender', 'useFullscreenForCaptionAndSender', {
+  set: (_, newState) => {
+    config.useFullscreenForCaptionAndSender = newState;
+    config.writeConfig();
+    // Update the menu afterwards
+    return true
+  },
+  isSet: () => config.useFullscreenForCaptionAndSender,
+  joinLastRow: true
+})
+
+menu.interact('Exit', 'unique', {
+  do: async context => {
+    await deleteMenuFromContext(context);
+    return false;
+  }
+})
+
+
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== "undefined") {
+  module.exports = menu;
+}

--- a/js/botConfigMenu.js
+++ b/js/botConfigMenu.js
@@ -1,6 +1,7 @@
 const langDefault = 'en';
 const langPath = __dirname + '/../config/i18n/bot/';
 const botPhrases = {};
+const { logger, rendererLogger } = require("./logger");
 
 const {MenuTemplate, MenuMiddleware, deleteMenuFromContext} = require('telegraf-inline-menu')
 
@@ -11,9 +12,12 @@ const menu = new MenuTemplate(() => 'Configuration-Menu');
 
 menu.toggle('whitelistChats', 'whitelistChats', {
   set: (_, newState) => {
+    logger.info("Config-Change for whitelistChats:");
     if (newState) {
+      logger.info("New whitelistChats: "+config.whitelistAdmins);
       config.whitelistChats = config.whitelistAdmins;
     } else {
+      logger.info("WhitelistChats is now empty");
       config.whitelistChats = [];
     }
     config.writeConfig();
@@ -29,6 +33,7 @@ menu.toggle('botReply', 'botReply', {
   set: (_, newState) => {
     config.botReply = newState;
     config.writeConfig();
+    logger.info("Config-Change for botReply: "+newState);
     // Update the menu afterwards
     return true
   },
@@ -40,6 +45,7 @@ menu.toggle('showVideos', 'showVideos', {
   set: (_, newState) => {
     config.showVideos = newState;
     config.writeConfig();
+    logger.info("Config-Change for showVideos: "+newState);
     // Update the menu afterwards
     return true
   },
@@ -51,6 +57,7 @@ menu.toggle('playVideoAudio', 'playVideoAudio', {
   set: (_, newState) => {
     config.playVideoAudio = newState;
     config.writeConfig();
+    logger.info("Config-Change for playVideoAudio: "+newState);
     // Update the menu afterwards
     return true
   },
@@ -62,6 +69,7 @@ menu.toggle('randomOrder', 'randomOrder', {
   set: (_, newState) => {
     config.randomOrder = newState;
     config.writeConfig();
+    logger.info("Config-Change for randomOrder: "+newState);
     // Update the menu afterwards
     return true
   },
@@ -73,6 +81,7 @@ menu.toggle('autoDeleteImages', 'autoDeleteImages', {
   set: (_, newState) => {
     config.autoDeleteImages = newState;
     config.writeConfig();
+    logger.info("Config-Change for autoDeleteImages: "+newState);
     // Update the menu afterwards
     return true
   },
@@ -84,6 +93,7 @@ menu.toggle('showSender', 'showSender', {
   set: (_, newState) => {
     config.showSender = newState;
     config.writeConfig();
+    logger.info("Config-Change for showSender: "+newState);
     // Update the menu afterwards
     return true
   },
@@ -95,6 +105,7 @@ menu.toggle('showCaption', 'showCaption', {
   set: (_, newState) => {
     config.showCaption = newState;
     config.writeConfig();
+    logger.info("Config-Change for showCaption: "+newState);
     // Update the menu afterwards
     return true
   },
@@ -106,6 +117,7 @@ menu.toggle('useFullscreenForCaptionAndSender', 'useFullscreenForCaptionAndSende
   set: (_, newState) => {
     config.useFullscreenForCaptionAndSender = newState;
     config.writeConfig();
+    logger.info("Config-Change for useFullscreenForCaptionAndSender: "+newState);
     // Update the menu afterwards
     return true
   },

--- a/js/botSendMessage.js
+++ b/js/botSendMessage.js
@@ -14,7 +14,6 @@ botPhrases[langDefault] = require(langPath + langDefault);
  */
 const botSendMessage = (telegram, ctx, constant, chatId, ...args) => {
   const langSender = ctx.from.language_code.substr(0, 2).toLowerCase();
-  console.log(langSender);
   if (!botPhrases[langSender]) {
     try {
       botPhrases[langSender] = Object.assign({}, botPhrases[langDefault], require(langPath + langSender));

--- a/js/botSendMessage.js
+++ b/js/botSendMessage.js
@@ -1,0 +1,37 @@
+const langDefault = 'en';
+const langPath =  __dirname + '/../config/i18n/bot/';
+const botPhrases = {};
+
+botPhrases[langDefault] = require(langPath + langDefault);
+
+/**
+ * Replies using the phrase for the sender's language
+ * @param  {Object} telegram Telegraf Object
+ * @param  {Object} ctx      telegraf request
+ * @param  {string} constant The constant to use
+ * @param  {int} chatId      The ChatId to send to
+ * @param  {array} args     [optional] Additional arguments to pass when the constant returns a function
+ */
+const botSendMessage = (telegram, ctx, constant, chatId, ...args) => {
+  const langSender = ctx.from.language_code.substr(0, 2).toLowerCase();
+  console.log(langSender);
+  if (!botPhrases[langSender]) {
+    try {
+      botPhrases[langSender] = Object.assign({}, botPhrases[langDefault], require(langPath + langSender));
+    } catch (e) {
+      // language file does'nt exist. Reference default language
+      botPhrases[langSender] = botPhrases[langDefault];
+    }
+  }
+  // Whenthe phrase is a function, it is called and the additional arguments are passed
+  if (typeof botPhrases[langSender][constant] === 'function') {
+    telegram.sendMessage(chatId, botPhrases[langSender][constant](...args))
+  } else {
+    telegram.sendMessage(chatId, botPhrases[langSender][constant])
+  }
+};
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== "undefined") {
+  module.exports = botSendMessage;
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "sweetalert": "^2.1.2",
     "sweetalert2": "^9.5.4",
     "telegraf": "^3.35.0",
+    "telegraf-inline-menu": "^5.3.0",
     "velocity-animate": "^1.5.2",
     "winston": "^3.2.1"
   }


### PR DESCRIPTION
One more step towards a texteditor free configuration!
1) If your user is admin, you are able to do some basic Configuration by sending '/settings' to the Bot and follow the inline-menu.
   - Currently I only implemented bools, but it should be possible to manipulate other parameters (like in the dialog with the BotFather).
    - Furthermore there is a button to enable and disable the whitelist of Chat. When enabled, the admin list is copied into the whitelist.

2) The welcome message will now also be send, when sending the command '/start'. Because Telegram overs a button for that command on the first interaction, this is in my eyes the most userfriendly way.
Furthermore the admin will be informed about a new user (this could be the first step for the whitelist workflow....)


Feel free to share your impressions and opinions.
